### PR TITLE
fix #36 - Add support for expression-based contracts

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -20,6 +20,6 @@
 	}
 	],
 	"dependencies": {
-		"libdparse": "~>0.8.0-alpha.1"
+		"libdparse": "~>0.9.0"
 	}
 }


### PR DESCRIPTION
Actually it's just that the upgrade is needed by D-Scanner