### PR TITLE
bump to libdparse 0.14.0

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -20,6 +20,6 @@
 	}
 	],
 	"dependencies": {
-		"libdparse": "~>0.13.0"
+		"libdparse": "~>0.14.0"
 	}
 }


### PR DESCRIPTION
for new 0.8.0 release (for compatibility with other tools)