### PR TITLE
upgrade max libdparse version to <1.0.0

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -20,6 +20,6 @@
 	}
 	],
 	"dependencies": {
-		"libdparse": ">=0.13.0 <0.18.0"
+		"libdparse": ">=0.13.0 <1.0.0"
 	}
 }


### PR DESCRIPTION
needed for DScanner libdparse update

The only thing used from libdparse in libddoc is the tokenizer, so any version should suffice. I made it <1.0.0 in case we still plan to add major breaking changes at some point to the tokenizing system.

The auto tester should always try <1.0.0 for the latest version, which DUB will automatically make the highest available version